### PR TITLE
Sanitize poster link in AI movie fetch

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -228,6 +228,10 @@ exports.aiFindMovie = onRequest({ timeoutSeconds: 120 }, async (req, res) => {
     const movie = extractMovieObject(data);
     setCors(res);
     if (movie) {
+      if (typeof movie.poster_link === 'string') {
+        const match = movie.poster_link.match(/https?:\/\/\S+/);
+        if (match) movie.poster_link = match[0];
+      }
       return res.status(200).json(movie);
     }
     // Fallback: return raw API JSON to aid debugging


### PR DESCRIPTION
## Summary
- Clean up AI movie search response by extracting only the poster URL

## Testing
- `npm test` *(fails: useLocation() may be used only in the context of a <Router> component)*
- `npm --prefix mcp test`


------
https://chatgpt.com/codex/tasks/task_e_68bb22a5f7648323bcdfddbc3f7e3131