### PR TITLE
Add movie detail dialog with full-screen mobile view

### DIFF
--- a/web/src/pages/MoviesPage.jsx
+++ b/web/src/pages/MoviesPage.jsx
@@ -1,14 +1,17 @@
+import { useState } from 'react';
 import Layout from '../ui/Layout.jsx';
 import FiltersBar from '../ui/FiltersBar.jsx';
 import MoviesGrid from '../ui/movies/MoviesGrid.jsx';
 import EmptyState from '../ui/movies/EmptyState.jsx';
 import SkeletonCard from '../ui/movies/SkeletonCard.jsx';
+import MovieDialog from '../ui/movies/MovieDialog.jsx';
 import useMoviesQuery from '../hooks/useMoviesQuery.js';
 
 const GENRES = ['Action', 'Adventure', 'Comedy', 'Drama', 'Sci-Fi'];
 
 export default function MoviesPage() {
   const { items, loading, error, setQuery, query } = useMoviesQuery();
+  const [selected, setSelected] = useState(null);
 
   return (
     <Layout search={query.q} onSearchChange={(v) => setQuery({ q: v, page: 0 })}>
@@ -28,9 +31,16 @@ export default function MoviesPage() {
           ))}
         </div>
       )}
-      {!loading && items.length > 0 && <MoviesGrid items={items} />}
+      {!loading && items.length > 0 && (
+        <MoviesGrid items={items} onSelect={(m) => setSelected(m)} />
+      )}
       {!loading && items.length === 0 && <EmptyState />}
       {error && <p className="text-error mt-4">{error}</p>}
+      <MovieDialog
+        movie={selected}
+        open={!!selected}
+        onClose={() => setSelected(null)}
+      />
     </Layout>
   );
 }

--- a/web/src/ui/movies/MovieCard.jsx
+++ b/web/src/ui/movies/MovieCard.jsx
@@ -1,9 +1,17 @@
-export default function MovieCard({ movie }) {
+export default function MovieCard({ movie, onSelect }) {
   const title = movie.title || movie.name || '(untitled)';
   const year = movie.year ? `(${movie.year})` : '';
   const genres = Array.isArray(movie.genre) ? movie.genre : [];
   return (
-    <div className="card bg-base-200 shadow">
+    <div
+      className="card bg-base-200 shadow cursor-pointer"
+      onClick={() => onSelect?.(movie)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') onSelect?.(movie);
+      }}
+    >
       {movie.poster_link && (
         <figure>
           <img src={movie.poster_link} alt={title} className="object-cover w-full h-72" />

--- a/web/src/ui/movies/MovieDialog.jsx
+++ b/web/src/ui/movies/MovieDialog.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+
+export default function MovieDialog({ movie, open, onClose }) {
+  if (!movie) return null;
+  const title = movie.title || movie.name || '(untitled)';
+  const year = movie.year ? `(${movie.year})` : '';
+  const genres = Array.isArray(movie.genre) ? movie.genre : [];
+  const actors = Array.isArray(movie.actors) ? movie.actors : [];
+  return (
+    <dialog className={`modal ${open ? 'modal-open' : ''}`} onClose={onClose}>
+      <div className="modal-box w-screen h-screen max-w-none rounded-none sm:max-w-xl sm:h-auto sm:rounded-box">
+        <button
+          type="button"
+          className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+          aria-label="Close"
+          onClick={onClose}
+        >
+          ✕
+        </button>
+        {movie.poster_link && (
+          <img
+            src={movie.poster_link}
+            alt={title}
+            className="object-cover w-full h-80 mb-4"
+          />
+        )}
+        <h3 className="font-bold text-lg mb-2">
+          {title} <span className="opacity-70">{year}</span>
+        </h3>
+        {genres.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-4">
+            {genres.map((g) => (
+              <span key={g} className="badge badge-outline">
+                {g}
+              </span>
+            ))}
+          </div>
+        )}
+        {actors.length > 0 && (
+          <div>
+            <h4 className="font-semibold mb-1">Actors</h4>
+            <ul className="list-disc list-inside">
+              {actors.map((a) => (
+                <li key={a}>{a}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+      <form method="dialog" className="modal-backdrop" onClick={onClose}>
+        <button>close</button>
+      </form>
+    </dialog>
+  );
+}

--- a/web/src/ui/movies/MovieDialog.jsx
+++ b/web/src/ui/movies/MovieDialog.jsx
@@ -8,44 +8,49 @@ export default function MovieDialog({ movie, open, onClose }) {
   const actors = Array.isArray(movie.actors) ? movie.actors : [];
   return (
     <dialog className={`modal ${open ? 'modal-open' : ''}`} onClose={onClose}>
-      <div className="modal-box w-screen h-screen max-w-none rounded-none sm:max-w-xl sm:h-auto sm:rounded-box">
+      {/* Constrain dialog to viewport and use a portrait layout */}
+      <div className="modal-box w-[92vw] max-w-sm sm:max-w-md md:max-w-lg max-h-[92dvh] overflow-y-auto p-0">
         <button
           type="button"
-          className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+          className="btn btn-sm btn-circle absolute right-2 top-2 z-10 bg-white text-gray-800 border border-base-300 shadow hover:bg-white/90"
           aria-label="Close"
           onClick={onClose}
         >
           ✕
         </button>
         {movie.poster_link && (
-          <img
-            src={movie.poster_link}
-            alt={title}
-            className="object-cover w-full h-80 mb-4"
-          />
-        )}
-        <h3 className="font-bold text-lg mb-2">
-          {title} <span className="opacity-70">{year}</span>
-        </h3>
-        {genres.length > 0 && (
-          <div className="flex flex-wrap gap-2 mb-4">
-            {genres.map((g) => (
-              <span key={g} className="badge badge-outline">
-                {g}
-              </span>
-            ))}
+          <div className="w-full bg-base-200" style={{ aspectRatio: '2 / 3' }}>
+            <img
+              src={movie.poster_link}
+              alt={title}
+              className="w-full h-full object-cover"
+            />
           </div>
         )}
-        {actors.length > 0 && (
-          <div>
-            <h4 className="font-semibold mb-1">Actors</h4>
-            <ul className="list-disc list-inside">
-              {actors.map((a) => (
-                <li key={a}>{a}</li>
+        <div className="p-4">
+          <h3 className="font-bold text-lg mb-2">
+            {title} <span className="opacity-70">{year}</span>
+          </h3>
+          {genres.length > 0 && (
+            <div className="flex flex-wrap gap-2 mb-4">
+              {genres.map((g) => (
+                <span key={g} className="badge badge-outline">
+                  {g}
+                </span>
               ))}
-            </ul>
-          </div>
-        )}
+            </div>
+          )}
+          {actors.length > 0 && (
+            <div>
+              <h4 className="font-semibold mb-1">Actors</h4>
+              <ul className="list-disc list-inside">
+                {actors.map((a) => (
+                  <li key={a}>{a}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
       </div>
       <form method="dialog" className="modal-backdrop" onClick={onClose}>
         <button>close</button>

--- a/web/src/ui/movies/MovieDialog.test.jsx
+++ b/web/src/ui/movies/MovieDialog.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { test, expect } from 'vitest';
+import '@testing-library/jest-dom';
+import MovieDialog from './MovieDialog.jsx';
+
+const movie = {
+  title: 'Test Movie',
+  year: 2020,
+  actors: ['A', 'B'],
+  genre: ['Drama'],
+  poster_link: 'http://example.com/poster.jpg',
+};
+
+test('shows movie details', () => {
+  render(<MovieDialog movie={movie} open={true} onClose={() => {}} />);
+  expect(screen.getByText('Test Movie')).toBeInTheDocument();
+  expect(screen.getByText('(2020)')).toBeInTheDocument();
+  expect(screen.getByText('Actors')).toBeInTheDocument();
+  expect(screen.getByText('A')).toBeInTheDocument();
+});

--- a/web/src/ui/movies/MoviesGrid.jsx
+++ b/web/src/ui/movies/MoviesGrid.jsx
@@ -1,10 +1,10 @@
 import MovieCard from './MovieCard.jsx';
 
-export default function MoviesGrid({ items }) {
+export default function MoviesGrid({ items, onSelect }) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-6 gap-4">
       {items.map((m) => (
-        <MovieCard key={m.id} movie={m} />
+        <MovieCard key={m.id} movie={m} onSelect={onSelect} />
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `MovieDialog` component to show detailed movie info in a modal that occupies the full screen on mobile.
- Wire `MoviesPage` and grid/card components to open the dialog when a movie is selected.
- Include unit tests for the new dialog.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c55affc2408323b8a4e0fa8f3244aa