### PR TITLE
feat: add landscape posters and hero carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Each movie document stored in Firestore follows this JSON structure:
   "year": 1992,
   "actors": ["Tom Cruise", "Jack Nicholson", "Demi Moore"],
   "genre": ["Drama", "Thriller"],
-  "poster_link": "https://m.media-amazon.com/images/M/MV5BOGVhMTUwYzEtZGQ1ZC00Nzg1LTk0OGUtMDk0NDM0ZmZlN2E0XkEyXkFqcGc@._V1_SX300.jpg"
+  "poster_link": "https://m.media-amazon.com/images/M/MV5BOGVhMTUwYzEtZGQ1ZC00Nzg1LTk0OGUtMDk0NDM0ZmZlN2E0XkEyXkFqcGc@._V1_SX300.jpg",
+  "landscape_poster_link": "https://m.media-amazon.com/images/L/landscape.jpg"
 }
 ```
 
@@ -69,6 +70,7 @@ Formal specification [JSON Schema](docs/schemas/movie.schema.json)
 * **actors** *(array of strings)* – List of main cast members.
 * **genre** *(array of strings)* – Genre tags (e.g., Drama, Thriller).
 * **poster\_link** *(string/URL)* – Link to the movie poster image.
+* **landscape\_poster\_link** *(string/URL)* – Link to a landscape-oriented poster image.
 
 ---
 
@@ -76,6 +78,7 @@ Formal specification [JSON Schema](docs/schemas/movie.schema.json)
 
 * 🔐 **Authentication**: Google (and optional email/password) sign-in with Firebase Auth.
 * 📖 **Read-only UI**: SPA displays `items` collection entries from Firestore in real-time.
+* 🎞️ **Hero Carousel**: Home page fetches four random movies via `/randomItems` and shows their landscape posters.
 * 🔧 **MCP tools** (for ChatGPT):
 
   * `listItems(limit?)`
@@ -83,6 +86,7 @@ Formal specification [JSON Schema](docs/schemas/movie.schema.json)
   * `createItem({ title, description? })`
   * `updateItem({ id, title?, description? })`
   * `deleteItem(id)`
+  * `randomItems()` – fetch four random movies for the hero carousel
 * 🛡️ **Security**: Firestore rules permit **reads only** for authenticated users; **writes are blocked** at the UI layer and reserved for MCP.
 * 🚀 **Hosting**: Deployable to Firebase Hosting.
 

--- a/docs/schemas/movie.schema.json
+++ b/docs/schemas/movie.schema.json
@@ -23,6 +23,7 @@
       "description": "Genre tags (e.g., Drama, Thriller)"
     },
     "poster_link": { "type": "string", "format": "uri", "description": "Poster image URL" },
+    "landscape_poster_link": { "type": "string", "format": "uri", "description": "Landscape poster image URL" },
     "createdAt": { "type": ["integer", "string"], "description": "ms since epoch or ISO string" },
     "updatedAt": { "type": ["integer", "string"], "description": "ms since epoch or ISO string" }
   },
@@ -34,7 +35,8 @@
       "year": 1987,
       "actors": ["Jason Patric", "Corey Haim", "Dianne Wiest"],
       "genre": ["Comedy", "Horror"],
-      "poster_link": "https://m.media-amazon.com/images/M/MV5B....jpg"
+      "poster_link": "https://m.media-amazon.com/images/M/MV5B....jpg",
+      "landscape_poster_link": "https://m.media-amazon.com/images/L/landscape....jpg"
     }
   ]
 }

--- a/web/src/api/functions.js
+++ b/web/src/api/functions.js
@@ -26,8 +26,8 @@ async function call(path, { method = 'GET', body, token } = {}) {
   return ct.includes('application/json') ? res.json() : res.text();
 }
 
-export async function createItem({ title, name, year, actors, genre, poster_link }, token) {
-  return call('createItem', { method: 'POST', body: { title, name, year, actors, genre, poster_link }, token });
+export async function createItem({ title, name, year, actors, genre, poster_link, landscape_poster_link }, token) {
+  return call('createItem', { method: 'POST', body: { title, name, year, actors, genre, poster_link, landscape_poster_link }, token });
 }
 
 export async function deleteItem(id, token) {
@@ -51,4 +51,8 @@ export async function updateItem({ id, title, description }, token) {
 // Call the AI endpoint to fetch structured movie info
 export async function aiFindMovie({ title, year }, token) {
   return call('aiFindMovie', { method: 'POST', body: { title, year }, token });
+}
+
+export async function randomItems(token) {
+  return call('randomItems', { method: 'GET', token });
 }

--- a/web/src/pages/AIFindMovie.jsx
+++ b/web/src/pages/AIFindMovie.jsx
@@ -31,8 +31,6 @@ export default function AIFindMovie() {
     setError('');
     setAddOk('');
     try {
-      console.log("-------------");
-      console.log(result);
       const created = await createItem(result);
       setAddOk(`Added: ${created.id}`);
     } catch (err) {
@@ -70,16 +68,28 @@ export default function AIFindMovie() {
           <div className="card bg-base-200 shadow mb-6">
             <div className="card-body">
               <div className="flex gap-4">
-                {result.poster_link && (
-                  <img
-                    src={result.poster_link}
-                    alt={result.title || 'poster'}
-                    className="w-32 h-48 object-cover rounded"
-                    onError={(e) => {
-                      e.currentTarget.style.display = 'none';
-                    }}
-                  />
-                )}
+                <div className="flex gap-4">
+                  {result.poster_link && (
+                    <img
+                      src={result.poster_link}
+                      alt={result.title || 'poster'}
+                      className="w-32 h-48 object-cover rounded"
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                      }}
+                    />
+                  )}
+                  {result.landscape_poster_link && (
+                    <img
+                      src={result.landscape_poster_link}
+                      alt={result.title || 'landscape poster'}
+                      className="w-48 h-32 object-cover rounded"
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                      }}
+                    />
+                  )}
+                </div>
                 <div>
                   <h2 className="card-title">{result.title} {result.year ? `(${result.year})` : ''}</h2>
                   {Array.isArray(result.genre) && (

--- a/web/src/pages/MoviesPage.jsx
+++ b/web/src/pages/MoviesPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Layout from '../ui/Layout.jsx';
 import FiltersBar from '../ui/FiltersBar.jsx';
 import MoviesGrid from '../ui/movies/MoviesGrid.jsx';
@@ -6,12 +6,21 @@ import EmptyState from '../ui/movies/EmptyState.jsx';
 import SkeletonCard from '../ui/movies/SkeletonCard.jsx';
 import MovieDialog from '../ui/movies/MovieDialog.jsx';
 import useMoviesQuery from '../hooks/useMoviesQuery.js';
+import HeroCarousel from '../ui/movies/HeroCarousel.jsx';
+import { randomItems } from '../api/functions.js';
 
 const GENRES = ['Action', 'Adventure', 'Comedy', 'Drama', 'Sci-Fi'];
 
 export default function MoviesPage() {
   const { items, loading, error, setQuery, query } = useMoviesQuery();
   const [selected, setSelected] = useState(null);
+  const [hero, setHero] = useState([]);
+
+  useEffect(() => {
+    randomItems()
+      .then((d) => setHero(d.movies || []))
+      .catch(() => setHero([]));
+  }, []);
 
   return (
     <Layout search={query.q} onSearchChange={(v) => setQuery({ q: v, page: 0 })}>
@@ -24,6 +33,7 @@ export default function MoviesPage() {
           setQuery({ sort: s, dir: s === 'year' ? 'desc' : 'asc' })
         }
       />
+      <HeroCarousel movies={hero} />
       {loading && items.length === 0 && (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-6 gap-4">
           {Array.from({ length: 6 }).map((_, i) => (

--- a/web/src/pages/MoviesPage.test.jsx
+++ b/web/src/pages/MoviesPage.test.jsx
@@ -14,12 +14,16 @@ vi.mock('../hooks/useMoviesQuery.js', () => ({
   }),
 }));
 
-test('renders movie grid and search', () => {
+vi.mock('../api/functions.js', () => ({
+  randomItems: () => Promise.resolve({ movies: [] })
+}));
+
+test('renders movie grid and search', async () => {
   render(
     <MemoryRouter>
       <MoviesPage />
     </MemoryRouter>
   );
   expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
-  expect(screen.getByText('Movie 1')).toBeInTheDocument();
+  expect(await screen.findByText('Movie 1')).toBeInTheDocument();
 });

--- a/web/src/ui/movies/HeroCarousel.jsx
+++ b/web/src/ui/movies/HeroCarousel.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export default function HeroCarousel({ movies = [] }) {
+  if (!movies.length) return null;
+  return (
+    <div className="carousel w-full mb-6">
+      {movies.map((m) => {
+        const img = m.landscape_poster_link || m.poster_link;
+        return (
+          <a
+            key={m.id}
+            href={`#${m.id}`}
+            className="carousel-item relative w-full h-64 md:h-96"
+          >
+            {img && (
+              <img
+                src={img}
+                alt={m.title || 'poster'}
+                className="w-full h-full object-cover"
+              />
+            )}
+            <div className="absolute bottom-0 left-0 right-0 bg-gradient-to-t from-black/70 to-transparent p-4 text-white">
+              <h2 className="text-xl md:text-3xl font-semibold">
+                {m.title}
+              </h2>
+            </div>
+          </a>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/ui/movies/MovieCard.jsx
+++ b/web/src/ui/movies/MovieCard.jsx
@@ -4,6 +4,7 @@ export default function MovieCard({ movie, onSelect }) {
   const genres = Array.isArray(movie.genre) ? movie.genre : [];
   return (
     <div
+      id={movie.id}
       className="card bg-base-200 shadow cursor-pointer"
       onClick={() => onSelect?.(movie)}
       role="button"


### PR DESCRIPTION
## Summary
- support landscape poster URLs alongside portrait posters
- add randomItems endpoint and hero carousel on the movies page
- document landscape posters and new carousel endpoint

## Testing
- `npm test`
- `npm --prefix web run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c577c271e08323871594107153b14d