### PR TITLE
Use TMDB API for movie metadata and add landscape posters

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Each movie document stored in Firestore follows this JSON structure:
   "year": 1992,
   "actors": ["Tom Cruise", "Jack Nicholson", "Demi Moore"],
   "genre": ["Drama", "Thriller"],
-  "poster_link": "https://m.media-amazon.com/images/M/MV5BOGVhMTUwYzEtZGQ1ZC00Nzg1LTk0OGUtMDk0NDM0ZmZlN2E0XkEyXkFqcGc@._V1_SX300.jpg"
+  "poster_link": "https://m.media-amazon.com/images/M/MV5BOGVhMTUwYzEtZGQ1ZC00Nzg1LTk0OGUtMDk0NDM0ZmZlN2E0XkEyXkFqcGc@._V1_SX300.jpg",
+  "landscape_poster_link": "https://image.tmdb.org/t/p/w780/example.jpg"
 }
 ```
 
@@ -69,6 +70,7 @@ Formal specification [JSON Schema](docs/schemas/movie.schema.json)
 * **actors** *(array of strings)* – List of main cast members.
 * **genre** *(array of strings)* – Genre tags (e.g., Drama, Thriller).
 * **poster\_link** *(string/URL)* – Link to the movie poster image.
+* **landscape\_poster\_link** *(string/URL)* – Landscape-oriented poster image link.
 
 ---
 

--- a/docs/README_TMDB_API.md
+++ b/docs/README_TMDB_API.md
@@ -108,96 +108,37 @@ curl --request GET \
 ```
 ---
 
-## 3. Get Movie Credits
+## 3. Get Movie Details & Credits
+
+Fetch full movie details and cast in a single call.
 
 ### Endpoint
 ```
-GET /movie/{movie_id}/credits
+GET /movie/{movie_id}?append_to_response=credits
 ```
 
 ### Example
 ```bash
 curl --request GET \
-  --url 'https://api.themoviedb.org/3/movie/332562/credits?language=en-US' \
+  --url 'https://api.themoviedb.org/3/movie/332562?append_to_response=credits&language=en-US' \
   --header 'Authorization: Bearer ${TMDB_BEARER}' \
   --header 'accept: application/json'
 ```
 
-### Path Parameter
-- **`movie_id` (required)** — TMDB ID of the movie. Example: `332562`.
+### Response Highlights
+- `genres[]` – objects with `name` fields.
+- `credits.cast[]` – actor list; use the first few names.
+- `poster_path` – portrait poster.
+- `backdrop_path` – landscape backdrop.
 
-### Query Parameters
-- **`language` (optional, default: en-US)** — Language for translated fields.
-
-### Response Overview
-- **`cast`** — Array of actors with fields like `id`, `name`, `character`, `profile_path`, and `order` (billing order).  
-- **`crew`** — Array of crew members with fields like `id`, `name`, `job`, `department`, and `profile_path`.
-
-```
-{
-    "id": 332562,
-    "cast": [{
-            "adult": false,
-            "gender": 1,
-            "id": 237405,
-            "known_for_department": "Acting",
-            "name": "Lady Gaga",
-            "original_name": "Lady Gaga",
-            "popularity": 1.1999,
-            "profile_path": "/JHrvJgQ443QKdzcEpXirmWtjAx.jpg",
-            "cast_id": 1,
-            "character": "Ally Campana",
-            "credit_id": "57ea39dbc3a3687ffd007913",
-            "order": 0
-        }, {
-            "adult": false,
-            "gender": 2,
-            "id": 51329,
-            "known_for_department": "Acting",
-            "name": "Bradley Cooper",
-            "original_name": "Bradley Cooper",
-            "popularity": 1.7139,
-            "profile_path": "/sQq0nft6YZmJ7EMQwPcbaxym3AL.jpg",
-            "cast_id": 0,
-            "character": "Jackson Maine",
-            "credit_id": "57ea39cf925141374b0007e1",
-            "order": 1
-        }, {
-            "adult": false,
-            "gender": 2,
-            "id": 16431,
-            "known_for_department": "Acting",
-            "name": "Sam Elliott",
-            "original_name": "Sam Elliott",
-            "popularity": 2.057,
-            "profile_path": "/1K2IvGXFbKsgkExuUsRvy4F0c9e.jpg",
-            "cast_id": 12,
-            "character": "Bobby Maine",
-            "credit_id": "59218be0c3a3687a64058418",
-            "order": 2
-        }, {
-            "adult": false,
-            "gender": 2,
-            "id": 57906,
-            "known_for_department": "Acting",
-            "name": "Andrew Dice Clay",
-            "original_name": "Andrew Dice Clay",
-            "popularity": 0.4588,
-            "profile_path": "/xwNn8mJrhww89P2pIVkWnaTlqHw.jpg",
-            "cast_id": 13,
-            "character": "Lorenzo Campana",
-            "credit_id": "59218bfac3a3687a8e055c47",
-            "order": 3
-        }
-...
-```
+Use these image paths to build `poster_link` and `landscape_poster_link`.
 
 ---
 
 ## 4. Images
 
-TMDB responses include image paths (e.g., `poster_path`, `backdrop_path`, `profile_path`).  
-Construct full URLs as:
+TMDB responses include image paths such as `poster_path` (portrait posters) and `backdrop_path` (landscape backdrops).
+Construct full URLs for `poster_link` and `landscape_poster_link` as:
 
 ```
 https://image.tmdb.org/t/p/{SIZE}{PATH}
@@ -244,8 +185,8 @@ Best practices:
 - **Search Movies**:  
   `GET /search/movie`
 
-- **Movie Credits (Cast & Crew)**:  
-  `GET /movie/{movie_id}/credits`
+- **Movie Details & Credits**:
+  `GET /movie/{movie_id}?append_to_response=credits`
 
 - **Images (base)**:  
   `https://image.tmdb.org/t/p/{SIZE}{PATH}`

--- a/docs/schemas/movie.schema.json
+++ b/docs/schemas/movie.schema.json
@@ -23,6 +23,7 @@
       "description": "Genre tags (e.g., Drama, Thriller)"
     },
     "poster_link": { "type": "string", "format": "uri", "description": "Poster image URL" },
+    "landscape_poster_link": { "type": "string", "format": "uri", "description": "Landscape poster image URL" },
     "createdAt": { "type": ["integer", "string"], "description": "ms since epoch or ISO string" },
     "updatedAt": { "type": ["integer", "string"], "description": "ms since epoch or ISO string" }
   },
@@ -34,7 +35,8 @@
       "year": 1987,
       "actors": ["Jason Patric", "Corey Haim", "Dianne Wiest"],
       "genre": ["Comedy", "Horror"],
-      "poster_link": "https://m.media-amazon.com/images/M/MV5B....jpg"
+      "poster_link": "https://m.media-amazon.com/images/M/MV5B....jpg",
+      "landscape_poster_link": "https://image.tmdb.org/t/p/w780/example.jpg"
     }
   ]
 }

--- a/web/src/api/functions.js
+++ b/web/src/api/functions.js
@@ -26,8 +26,8 @@ async function call(path, { method = 'GET', body, token } = {}) {
   return ct.includes('application/json') ? res.json() : res.text();
 }
 
-export async function createItem({ title, name, year, actors, genre, poster_link }, token) {
-  return call('createItem', { method: 'POST', body: { title, name, year, actors, genre, poster_link }, token });
+export async function createItem({ title, name, year, actors, genre, poster_link, landscape_poster_link }, token) {
+  return call('createItem', { method: 'POST', body: { title, name, year, actors, genre, poster_link, landscape_poster_link }, token });
 }
 
 export async function deleteItem(id, token) {
@@ -48,7 +48,7 @@ export async function updateItem({ id, title, description }, token) {
   return call('updateItem', { method: 'PATCH', body: { id, title, description }, token });
 }
 
-// Call the AI endpoint to fetch structured movie info
-export async function aiFindMovie({ title, year }, token) {
-  return call('aiFindMovie', { method: 'POST', body: { title, year }, token });
+// Fetch movie info from TMDB
+export async function findMovie({ title, year }, token) {
+  return call('findMovie', { method: 'POST', body: { title, year }, token });
 }

--- a/web/src/pages/AIFindMovie.jsx
+++ b/web/src/pages/AIFindMovie.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import Layout from '../ui/Layout.jsx';
-import { aiFindMovie, createItem } from '../api/functions.js';
+import { findMovie, createItem } from '../api/functions.js';
 
 export default function AIFindMovie() {
   const [title, setTitle] = useState('Jurassic World Rebirth');
@@ -17,7 +17,7 @@ export default function AIFindMovie() {
     setResult(null);
     setLoading(true);
     try {
-      const data = await aiFindMovie({ title, year });
+      const data = await findMovie({ title, year });
       setResult(data);
     } catch (err) {
       setError(err.message || 'Failed to fetch movie');
@@ -43,7 +43,7 @@ export default function AIFindMovie() {
   return (
     <Layout>
       <div className="max-w-2xl mx-auto">
-        <h1 className="text-2xl font-semibold mb-4">AI: Find Movie</h1>
+        <h1 className="text-2xl font-semibold mb-4">TMDB: Find Movie</h1>
         <form onSubmit={onSearch} className="flex gap-2 mb-4">
           <input
             className="input input-bordered flex-1"
@@ -70,16 +70,28 @@ export default function AIFindMovie() {
           <div className="card bg-base-200 shadow mb-6">
             <div className="card-body">
               <div className="flex gap-4">
-                {result.poster_link && (
-                  <img
-                    src={result.poster_link}
-                    alt={result.title || 'poster'}
-                    className="w-32 h-48 object-cover rounded"
-                    onError={(e) => {
-                      e.currentTarget.style.display = 'none';
-                    }}
-                  />
-                )}
+                <div className="flex flex-col gap-2">
+                  {result.poster_link && (
+                    <img
+                      src={result.poster_link}
+                      alt={result.title || 'poster'}
+                      className="w-32 h-48 object-cover rounded"
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                      }}
+                    />
+                  )}
+                  {result.landscape_poster_link && (
+                    <img
+                      src={result.landscape_poster_link}
+                      alt={result.title || 'landscape poster'}
+                      className="w-48 h-28 object-cover rounded"
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                      }}
+                    />
+                  )}
+                </div>
                 <div>
                   <h2 className="card-title">{result.title} {result.year ? `(${result.year})` : ''}</h2>
                   {Array.isArray(result.genre) && (


### PR DESCRIPTION
## Summary
- Replace OpenAI movie lookup with TMDB API `findMovie` endpoint that returns cast, genres, poster and backdrop URLs
- Allow `landscape_poster_link` in movie objects and schema
- Update frontend helpers and search page to use TMDB and show landscape images

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c59dc6fe688323aa764c35a8911338