### PR TITLE
Update hero carousel interactions and styling

### DIFF
--- a/web/src/pages/MoviesPage.jsx
+++ b/web/src/pages/MoviesPage.jsx
@@ -32,14 +32,6 @@ export default function MoviesPage() {
     };
   }, []);
 
-  function scrollToCard(movie) {
-    if (!movie?.id) return;
-    const el = document.getElementById(`movie-${movie.id}`);
-    if (el && typeof el.scrollIntoView === 'function') {
-      el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-    }
-  }
-
   function handleDeleted(movie) {
     if (!movie?.id) return;
     setHiddenIds((prev) => {
@@ -63,7 +55,7 @@ export default function MoviesPage() {
         }
       />
       {hero.length > 0 && (
-        <HeroCarousel items={hero} onScrollTo={scrollToCard} />
+        <HeroCarousel items={hero} onSelect={setSelected} />
       )}
       {loading && items.length === 0 && (
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 xl:grid-cols-6 gap-4">

--- a/web/src/ui/movies/HeroCarousel.jsx
+++ b/web/src/ui/movies/HeroCarousel.jsx
@@ -1,100 +1,101 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-export default function HeroCarousel({ items = [], onScrollTo }) {
-  if (!items || items.length === 0) return null;
-
-  function bgFor(m) {
-    return m.landscape_poster_link || m.poster_link || '';
-  }
-
+export default function HeroCarousel({ items = [], onSelect }) {
   const containerRef = useRef(null);
   const [current, setCurrent] = useState(0);
+  const length = Array.isArray(items) ? items.length : 0;
 
-  function scrollToIndex(idx) {
+  const scrollToIndex = useCallback((idx) => {
     const container = containerRef.current;
     if (!container) return;
     const target = container.querySelector(`#hero-slide-${idx}`);
     if (target) {
       container.scrollTo({ left: target.offsetLeft, behavior: 'smooth' });
     }
-  }
+  }, [containerRef]);
 
-  // Auto-advance carousel every 5 seconds
   useEffect(() => {
-    if (!items || items.length === 0) return undefined;
+    if (length === 0) return undefined;
+    setCurrent((prev) => {
+      const safe = prev < length ? prev : 0;
+      scrollToIndex(safe);
+      return safe;
+    });
     const id = setInterval(() => {
       setCurrent((prev) => {
-        const next = (prev + 1) % items.length;
+        const next = (prev + 1) % length;
         scrollToIndex(next);
         return next;
       });
     }, 5000);
     return () => clearInterval(id);
-  }, [items.length]);
+  }, [length, scrollToIndex]);
+
+  const bgFor = (m) => m.landscape_poster_link || m.poster_link || '';
+
+  if (length === 0) return null;
 
   return (
     <div ref={containerRef} className="carousel w-full mb-6 h-64 md:h-80 lg:h-96 rounded-box overflow-hidden">
       {items.map((m, idx) => {
         const bg = bgFor(m);
-        const prev = (idx - 1 + items.length) % items.length;
-        const next = (idx + 1) % items.length;
         const title = m.title || m.name || '(untitled)';
         const year = m.year ? `(${m.year})` : '';
+        const isActive = current === idx;
         return (
-          <div id={`hero-slide-${idx}`} className="carousel-item relative w-full" key={m.id || idx}>
+          <div
+            id={`hero-slide-${idx}`}
+            className="carousel-item relative w-full"
+            key={m.id || idx}
+            aria-hidden={!isActive}
+            data-active={isActive ? 'true' : undefined}
+          >
             <div
               className="w-full h-full bg-center bg-cover"
               style={{ backgroundImage: bg ? `url(${bg})` : undefined }}
             />
             <div className="absolute inset-0 bg-gradient-to-t from-base-100/80 via-base-100/20 to-transparent" />
-            <div className="absolute bottom-0 left-0 right-0 p-6 md:p-8 flex flex-col gap-3">
-              <div className="inline-block max-w-[90%]">
-                <h2 className="text-xl md:text-3xl font-semibold inline-block bg-white/25 text-black rounded-xl px-3 py-1 shadow-sm backdrop-blur-sm">
-                  <span>{title}</span>{' '}{year && <span className="opacity-80">{year}</span>}
+            <div className="absolute inset-0 flex items-end px-6 md:px-8 pb-4 md:pb-6">
+              <button
+                type="button"
+                className="group inline-flex max-w-[90%] bg-transparent border-none p-0 text-left rounded-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent3)]/60"
+                onClick={() => onSelect?.(m)}
+                aria-label={`View details for ${title}`}
+              >
+                <h2 className="text-xl md:text-3xl font-semibold inline-flex items-center bg-white/25 text-[color:var(--accent3)] rounded-xl px-3 py-1 shadow-sm backdrop-blur-sm transition group-hover:bg-white/35">
+                  <span>{title}</span>{' '}
+                  {year && <span className="opacity-80">{year}</span>}
                 </h2>
-              </div>
-              <div className="flex gap-2">
-                {m.id && (
-                  <a
-                    href={`#movie-${m.id}`}
-                    onClick={(e) => {
-                      // Prefer smooth scroll if provided
-                      e.preventDefault();
-                      onScrollTo?.(m);
-                    }}
-                    className="inline-flex items-center bg-white/25 text-black rounded-xl px-3 py-1.5 md:px-4 md:py-2 shadow-sm backdrop-blur-sm hover:bg-white/35 transition"
-                  >
-                    Jump to card
-                  </a>
-                )}
-              </div>
+              </button>
             </div>
             <div className="absolute left-4 right-4 top-1/2 -translate-y-1/2 flex justify-between">
               <button
                 type="button"
-                className="btn btn-circle"
+                className="inline-flex items-center justify-center rounded-full w-10 h-10 md:w-12 md:h-12 bg-white/20 text-[color:var(--accent3)] border border-white/40 shadow-sm backdrop-blur-sm transition hover:bg-white/35 focus:outline-none focus:ring-2 focus:ring-[color:var(--accent3)]/50"
                 onClick={(e) => {
                   e.preventDefault();
                   setCurrent((p) => {
-                    const idx = (p - 1 + items.length) % items.length;
+                    const idx = (p - 1 + length) % length;
                     scrollToIndex(idx);
                     return idx;
                   });
                 }}
+                aria-label="Previous"
               >
                 ❮
               </button>
               <button
                 type="button"
-                className="btn btn-circle"
+                className="inline-flex items-center justify-center rounded-full w-10 h-10 md:w-12 md:h-12 bg-white/20 text-[color:var(--accent3)] border border-white/40 shadow-sm backdrop-blur-sm transition hover:bg-white/35 focus:outline-none focus:ring-2 focus:ring-[color:var(--accent3)]/50"
                 onClick={(e) => {
                   e.preventDefault();
                   setCurrent((p) => {
-                    const idx = (p + 1) % items.length;
+                    const idx = (p + 1) % length;
                     scrollToIndex(idx);
                     return idx;
                   });
                 }}
+                aria-label="Next"
               >
                 ❯
               </button>

--- a/web/src/ui/movies/MovieDialog.jsx
+++ b/web/src/ui/movies/MovieDialog.jsx
@@ -1,13 +1,18 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { deleteItem } from '../../api/functions.js';
 
 export default function MovieDialog({ movie, open, onClose, onDeleted }) {
+  const [deleting, setDeleting] = useState(false);
+
+  useEffect(() => {
+    if (!movie) setDeleting(false);
+  }, [movie]);
+
   if (!movie) return null;
   const title = movie.title || movie.name || '(untitled)';
   const year = movie.year ? `(${movie.year})` : '';
   const genres = Array.isArray(movie.genre) ? movie.genre : [];
   const actors = Array.isArray(movie.actors) ? movie.actors : [];
-  const [deleting, setDeleting] = useState(false);
 
   async function handleDelete() {
     if (!movie?.id) return;


### PR DESCRIPTION
## Summary
- remove the hero carousel's "jump to card" button and reposition the headline as a selectable chip
- restyle the carousel navigation controls to match the translucent accent treatment and make the title open the movie dialog
- tidy hook usage so linting passes for the carousel and dialog components

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8d3f185248323bb24c4c75dc1db2a