### PR TITLE
Add Watched action to movie dialog

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -79,7 +79,7 @@ exports.createItem = onRequest(async (req, res) => {
   try {
     const now = Date.now();
     // Whitelist known movie fields and drop undefined values
-    const allowed = ['name', 'title', 'year', 'actors', 'genre', 'poster_link', 'landscape_poster_link', 'description', 'createdAt', 'updatedAt'];
+    const allowed = ['name', 'title', 'year', 'actors', 'genre', 'poster_link', 'landscape_poster_link', 'description', 'createdAt', 'updatedAt', 'lastWatched'];
     const doc = {};
     for (const key of allowed) {
       if (Object.prototype.hasOwnProperty.call(body, key) && body[key] !== undefined) {
@@ -109,7 +109,7 @@ exports.updateItem = onRequest(async (req, res) => {
   const id = typeof body.id === 'string' ? body.id : '';
   if (!id) return res.status(400).json({ error: 'id is required' });
   // Whitelist updatable fields and ignore undefined values
-  const allowed = ['name', 'title', 'year', 'actors', 'genre', 'poster_link', 'landscape_poster_link', 'description'];
+  const allowed = ['name', 'title', 'year', 'actors', 'genre', 'poster_link', 'landscape_poster_link', 'description', 'lastWatched'];
   const patch = {};
   for (const key of allowed) {
     if (Object.prototype.hasOwnProperty.call(body, key) && body[key] !== undefined) {

--- a/web/src/api/functions.js
+++ b/web/src/api/functions.js
@@ -44,8 +44,11 @@ export async function listItems(limit, token) {
   return call(`listItems${qp}`, { method: 'GET', token });
 }
 
-export async function updateItem({ id, title, description }, token) {
-  return call('updateItem', { method: 'PATCH', body: { id, title, description }, token });
+export async function updateItem(data, token) {
+  if (!data || typeof data !== 'object') {
+    throw new Error('updateItem requires an object with the fields to update');
+  }
+  return call('updateItem', { method: 'PATCH', body: data, token });
 }
 
 // Fetch movie info from TMDB

--- a/web/src/ui/movies/MovieDialog.jsx
+++ b/web/src/ui/movies/MovieDialog.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { deleteItem } from '../../api/functions.js';
+import React, { useEffect, useState } from 'react';
+import { deleteItem, updateItem } from '../../api/functions.js';
 
 export default function MovieDialog({ movie, open, onClose, onDeleted }) {
   if (!movie) return null;
@@ -8,6 +8,48 @@ export default function MovieDialog({ movie, open, onClose, onDeleted }) {
   const genres = Array.isArray(movie.genre) ? movie.genre : [];
   const actors = Array.isArray(movie.actors) ? movie.actors : [];
   const [deleting, setDeleting] = useState(false);
+  const [markingWatched, setMarkingWatched] = useState(false);
+  const [lastWatched, setLastWatched] = useState(movie.lastWatched);
+
+  useEffect(() => {
+    setLastWatched(movie.lastWatched);
+    setMarkingWatched(false);
+    setDeleting(false);
+  }, [movie]);
+
+  let lastWatchedInfo = null;
+  if (lastWatched !== undefined && lastWatched !== null) {
+    let date;
+    if (typeof lastWatched === 'number' || typeof lastWatched === 'string') {
+      date = new Date(lastWatched);
+    } else if (
+      typeof lastWatched === 'object' &&
+      lastWatched !== null &&
+      typeof lastWatched.seconds === 'number'
+    ) {
+      date = new Date(lastWatched.seconds * 1000);
+    }
+    if (date && !Number.isNaN(date.getTime())) {
+      lastWatchedInfo = {
+        iso: date.toISOString(),
+        label: date.toLocaleString(),
+      };
+    }
+  }
+
+  async function handleWatched() {
+    if (!movie?.id || markingWatched) return;
+    try {
+      setMarkingWatched(true);
+      const now = Date.now();
+      const updated = await updateItem({ id: movie.id, lastWatched: now });
+      setLastWatched(updated?.lastWatched ?? now);
+    } catch (err) {
+      alert(err?.message || 'Failed to update movie');
+    } finally {
+      setMarkingWatched(false);
+    }
+  }
 
   async function handleDelete() {
     if (!movie?.id) return;
@@ -26,7 +68,7 @@ export default function MovieDialog({ movie, open, onClose, onDeleted }) {
     }
   }
   return (
-    <dialog className={`modal ${open ? 'modal-open' : ''}`} onClose={onClose}>
+    <dialog open={open} className={`modal ${open ? 'modal-open' : ''}`} onClose={onClose}>
       {/* Constrain dialog to viewport and use a portrait layout */}
       <div className="modal-box w-[92vw] max-w-sm sm:max-w-md md:max-w-lg max-h-[92dvh] overflow-y-auto p-0">
         <button
@@ -69,15 +111,31 @@ export default function MovieDialog({ movie, open, onClose, onDeleted }) {
               </ul>
             </div>
           )}
-          <div className="mt-6 flex justify-end">
-            <button
-              type="button"
-              className={`btn btn-error ${deleting ? 'btn-disabled loading' : ''}`}
-              onClick={handleDelete}
-              disabled={deleting}
-            >
-              {deleting ? 'Deleting…' : 'Delete'}
-            </button>
+          <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            {lastWatchedInfo && (
+              <p className="text-sm text-base-content/70">
+                Last watched:{' '}
+                <time dateTime={lastWatchedInfo.iso}>{lastWatchedInfo.label}</time>
+              </p>
+            )}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                className={`btn btn-primary ${markingWatched ? 'btn-disabled loading' : ''}`}
+                onClick={handleWatched}
+                disabled={markingWatched || deleting}
+              >
+                {markingWatched ? 'Saving…' : 'Watched'}
+              </button>
+              <button
+                type="button"
+                className={`btn btn-error ${deleting ? 'btn-disabled loading' : ''}`}
+                onClick={handleDelete}
+                disabled={deleting}
+              >
+                {deleting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/ui/movies/MovieDialog.test.jsx
+++ b/web/src/ui/movies/MovieDialog.test.jsx
@@ -1,9 +1,28 @@
-import { render, screen } from '@testing-library/react';
-import { test, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { test, expect, vi, afterEach } from 'vitest';
 import '@testing-library/jest-dom';
+
+const { mockDeleteItem, mockUpdateItem } = vi.hoisted(() => ({
+  mockDeleteItem: vi.fn().mockResolvedValue({}),
+  mockUpdateItem: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('../../api/functions.js', () => ({
+  deleteItem: mockDeleteItem,
+  updateItem: mockUpdateItem,
+}));
+
+// Import after mocking API helpers so the component uses the mocked versions.
 import MovieDialog from './MovieDialog.jsx';
 
+afterEach(() => {
+  vi.clearAllMocks();
+  mockDeleteItem.mockResolvedValue({});
+  mockUpdateItem.mockResolvedValue({});
+});
+
 const movie = {
+  id: 'movie-1',
   title: 'Test Movie',
   year: 2020,
   actors: ['A', 'B'],
@@ -17,4 +36,26 @@ test('shows movie details', () => {
   expect(screen.getByText('(2020)')).toBeInTheDocument();
   expect(screen.getByText('Actors')).toBeInTheDocument();
   expect(screen.getByText('A')).toBeInTheDocument();
+});
+
+test('marks movie as watched and shows last watched time', async () => {
+  const before = Date.now();
+  mockUpdateItem.mockImplementation(async ({ lastWatched, ...rest }) => ({
+    ...rest,
+    id: movie.id,
+    lastWatched,
+  }));
+
+  render(<MovieDialog movie={movie} open={true} onClose={() => {}} />);
+  const watchedButton = screen.getByRole('button', { name: /watched/i });
+  fireEvent.click(watchedButton);
+  await waitFor(() => expect(mockUpdateItem).toHaveBeenCalledTimes(1));
+  const args = mockUpdateItem.mock.calls[0][0];
+  expect(args.id).toBe(movie.id);
+  expect(typeof args.lastWatched).toBe('number');
+  expect(args.lastWatched).toBeGreaterThanOrEqual(before);
+  expect(args.lastWatched).toBeLessThanOrEqual(Date.now());
+  await waitFor(() => {
+    expect(screen.getByText(/last watched/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- add a "Watched" control to the movie dialog that records the last watched timestamp and surfaces it in the UI
- allow the Functions API and frontend client to send arbitrary update fields including the new `lastWatched` value
- cover the new behaviour with unit tests for the dialog component

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8d4d5f63c8323a721664e36ef0e5f