### PR TITLE
Add weekly picks planner

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -10,6 +10,8 @@ if (!admin.apps.length) {
 const db = admin.firestore();
 const collectionName = process.env.FIRESTORE_COLLECTION || 'items';
 const col = () => db.collection(collectionName);
+const weeklyCollectionName = process.env.WEEKLY_PICKS_COLLECTION || 'weeklyPicks';
+const weeklyCol = () => db.collection(weeklyCollectionName);
 
 function setCors(res) {
   res.set('Access-Control-Allow-Origin', '*');
@@ -151,6 +153,9 @@ exports.randomItems = onRequest(async (req, res) => {
   handleOptions(req, res);
   if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
   try {
+    const countParam = req.query.count ? parseInt(String(req.query.count), 10) : undefined;
+    const requestedCount = Number.isFinite(countParam) && countParam > 0 ? countParam : 4;
+    const count = Math.min(requestedCount, 20);
     const snap = await col().limit(50).get();
     const docs = snap.docs
       .map((d) => ({ id: d.id, ...d.data() }))
@@ -164,14 +169,89 @@ exports.randomItems = onRequest(async (req, res) => {
       }
       return arr;
     }
-    const selected = shuffle(withLandscape).slice(0, 4);
-    if (selected.length < 4) {
-      selected.push(...shuffle(others).slice(0, 4 - selected.length));
-    }
+    const prioritized = shuffle([...withLandscape]);
+    const fallback = shuffle([...others]);
+    const combined = [...prioritized, ...fallback];
+    const selected = combined.slice(0, Math.min(count, combined.length));
     setCors(res);
     return res.status(200).json({ movies: selected });
   } catch (err) {
     logger.error('randomItems failed', err);
+    return res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+function sanitizeMovie(movie) {
+  if (!movie || typeof movie !== 'object') return null;
+  const allowed = [
+    'id',
+    'title',
+    'name',
+    'year',
+    'actors',
+    'genre',
+    'poster_link',
+    'landscape_poster_link',
+  ];
+  const cleaned = {};
+  for (const key of allowed) {
+    if (Object.prototype.hasOwnProperty.call(movie, key) && movie[key] !== undefined) {
+      cleaned[key] = movie[key];
+    }
+  }
+  if (!cleaned.id && !cleaned.title && !cleaned.name) return null;
+  return cleaned;
+}
+
+function sanitizePick(pick) {
+  if (!pick || typeof pick !== 'object') return null;
+  const date = typeof pick.date === 'string' ? pick.date : '';
+  if (!date) return null;
+  const movie = sanitizeMovie(pick.movie);
+  if (!movie) return null;
+  return { date, movie };
+}
+
+// GET /getWeeklyPicks
+exports.getWeeklyPicks = onRequest(async (req, res) => {
+  handleOptions(req, res);
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+  try {
+    const snap = await weeklyCol().orderBy('createdAt', 'desc').limit(1).get();
+    const doc = snap.docs[0];
+    const data = doc ? { id: doc.id, ...doc.data() } : null;
+    setCors(res);
+    return res.status(200).json(data);
+  } catch (err) {
+    logger.error('getWeeklyPicks failed', err);
+    return res.status(500).json({ error: 'Internal error' });
+  }
+});
+
+// POST /saveWeeklyPicks { picks: [{ date, movie }] }
+exports.saveWeeklyPicks = onRequest(async (req, res) => {
+  handleOptions(req, res);
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+  try {
+    const body = await readJson(req);
+    const rawPicks = Array.isArray(body.picks) ? body.picks : [];
+    const picks = rawPicks.map(sanitizePick).filter(Boolean);
+    if (picks.length !== 7) {
+      return res.status(400).json({ error: 'picks must contain 7 valid entries' });
+    }
+    const now = Date.now();
+    const doc = {
+      picks,
+      createdAt: now,
+      updatedAt: now,
+      startDate: picks[0]?.date || null,
+    };
+    const ref = await weeklyCol().add(doc);
+    const saved = await ref.get();
+    setCors(res);
+    return res.status(201).json({ id: ref.id, ...saved.data() });
+  } catch (err) {
+    logger.error('saveWeeklyPicks failed', err);
     return res.status(500).json({ error: 'Internal error' });
   }
 });

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -2,12 +2,14 @@ import { Routes, Route } from 'react-router-dom';
 import AuthGate from './auth/AuthGate.jsx';
 import MoviesPage from './pages/MoviesPage.jsx';
 import AIFindMovie from './pages/AIFindMovie.jsx';
+import WeeklyPicks from './pages/WeeklyPicks.jsx';
 
 export default function App() {
   return (
     <AuthGate>
       <Routes>
         <Route path="/" element={<MoviesPage />} />
+        <Route path="/weekly" element={<WeeklyPicks />} />
         <Route path="/ai" element={<AIFindMovie />} />
       </Routes>
     </AuthGate>

--- a/web/src/api/functions.js
+++ b/web/src/api/functions.js
@@ -54,8 +54,27 @@ export async function findMovie({ title, year }, token) {
 }
 
 // Fetch a few random items suitable for hero carousel
-export async function randomItems(token) {
-  const res = await call('randomItems', { method: 'GET', token });
+export async function randomItems(options, maybeToken) {
+  let count;
+  let token = maybeToken;
+  if (typeof options === 'number') {
+    count = options;
+  } else if (options && typeof options === 'object') {
+    ({ count } = options);
+    if (options.token && !token) token = options.token;
+  } else if (typeof options === 'string' && token === undefined) {
+    token = options;
+  }
+  const qp = typeof count === 'number' ? `?count=${count}` : '';
+  const res = await call(`randomItems${qp}`, { method: 'GET', token });
   // Backend returns { movies: [...] }
   return Array.isArray(res?.movies) ? res.movies : res;
+}
+
+export async function getWeeklyPicks(token) {
+  return call('getWeeklyPicks', { method: 'GET', token });
+}
+
+export async function saveWeeklyPicks(picks, token) {
+  return call('saveWeeklyPicks', { method: 'POST', body: { picks }, token });
 }

--- a/web/src/pages/WeeklyPicks.jsx
+++ b/web/src/pages/WeeklyPicks.jsx
@@ -1,0 +1,291 @@
+import { useEffect, useMemo, useState } from 'react';
+import Layout from '../ui/Layout.jsx';
+import { randomItems, getWeeklyPicks, saveWeeklyPicks } from '../api/functions.js';
+import { useAuth } from '../auth/AuthGate.jsx';
+
+const DAYS_TO_PICK = 7;
+const dayLabelFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: 'long',
+  month: 'short',
+  day: 'numeric',
+});
+const savedAtFormatter = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+function formatIsoDate(date) {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function parseIsoDate(value) {
+  if (typeof value !== 'string') return null;
+  const parts = value.split('-').map((part) => Number(part));
+  if (parts.length !== 3) return null;
+  const [year, month, day] = parts;
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return null;
+  const parsed = new Date(Date.UTC(year, month - 1, day, 12, 0, 0));
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+}
+
+function createEmptySchedule(startDate = new Date()) {
+  const base = new Date(startDate);
+  base.setHours(12, 0, 0, 0);
+  return Array.from({ length: DAYS_TO_PICK }, (_, index) => {
+    const date = new Date(base);
+    date.setDate(base.getDate() + index);
+    return {
+      date: formatIsoDate(date),
+      label: dayLabelFormatter.format(date),
+      movie: null,
+    };
+  });
+}
+
+function sortAndFormatPicks(picks) {
+  const scheduleFallback = createEmptySchedule();
+  return picks
+    .slice()
+    .sort((a, b) => {
+      const left = typeof a?.date === 'string' ? a.date : '';
+      const right = typeof b?.date === 'string' ? b.date : '';
+      return left.localeCompare(right);
+    })
+    .map((pick, index) => {
+      const fallback = scheduleFallback[index] || scheduleFallback[scheduleFallback.length - 1];
+      const date = typeof pick?.date === 'string' && pick.date ? pick.date : fallback.date;
+      const parsedDate = parseIsoDate(date);
+      const label = parsedDate ? dayLabelFormatter.format(parsedDate) : fallback.label;
+      const movie = pick?.movie && typeof pick.movie === 'object' ? pick.movie : null;
+      return { date, label, movie };
+    });
+}
+
+function extractMillis(value) {
+  if (!value) return null;
+  if (typeof value === 'number') return value;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value.toDate === 'function') return value.toDate().getTime();
+  if (typeof value._seconds === 'number') return value._seconds * 1000;
+  return null;
+}
+
+function WeeklyPickCard({ pick }) {
+  const { label, date, movie } = pick;
+  const poster = movie?.landscape_poster_link || movie?.poster_link;
+  return (
+    <div className="card bg-base-200 shadow-sm">
+      <div className="card-body">
+        <h3 className="card-title text-lg">{label}</h3>
+        <p className="text-sm opacity-70">{date}</p>
+        {movie ? (
+          <div className="mt-3 flex gap-4 items-start">
+            {poster && (
+              <img
+                src={poster}
+                alt={movie.title || movie.name || 'Movie poster'}
+                className="w-32 h-20 sm:w-36 sm:h-24 object-cover rounded"
+                onError={(event) => {
+                  event.currentTarget.style.visibility = 'hidden';
+                }}
+              />
+            )}
+            <div>
+              <p className="font-semibold text-base">
+                {movie.title || movie.name || 'Untitled Movie'}
+              </p>
+              {movie.year && (
+                <p className="text-sm opacity-80">Released: {movie.year}</p>
+              )}
+              {Array.isArray(movie.genre) && movie.genre.length > 0 && (
+                <p className="text-sm opacity-80">Genres: {movie.genre.slice(0, 3).join(', ')}</p>
+              )}
+              {Array.isArray(movie.actors) && movie.actors.length > 0 && (
+                <p className="text-sm opacity-80">Cast: {movie.actors.slice(0, 4).join(', ')}</p>
+              )}
+            </div>
+          </div>
+        ) : (
+          <p className="italic opacity-70 mt-3">No movie selected yet.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function WeeklyPicks() {
+  const { user } = useAuth();
+  const [picks, setPicks] = useState(() => createEmptySchedule());
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [spinLoading, setSpinLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [lastSavedDoc, setLastSavedDoc] = useState(null);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  const hasMovies = useMemo(() => picks.some((pick) => !!pick.movie), [picks]);
+  const lastSavedMillis = useMemo(() => extractMillis(lastSavedDoc?.updatedAt || lastSavedDoc?.createdAt), [lastSavedDoc]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setInitialLoading(true);
+      setError('');
+      try {
+        const data = await getWeeklyPicks();
+        if (cancelled) return;
+        if (data && Array.isArray(data.picks) && data.picks.length > 0) {
+          setPicks(sortAndFormatPicks(data.picks));
+          setLastSavedDoc(data);
+          setHasUnsavedChanges(false);
+        } else {
+          setPicks(createEmptySchedule());
+          setLastSavedDoc(null);
+          setHasUnsavedChanges(false);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err.message || 'Failed to load saved picks');
+          setPicks(createEmptySchedule());
+        }
+      } finally {
+        if (!cancelled) setInitialLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handlePickMovies() {
+    setError('');
+    setSuccess('');
+    setSpinLoading(true);
+    try {
+      const movies = await randomItems({ count: DAYS_TO_PICK });
+      if (!Array.isArray(movies) || movies.length < DAYS_TO_PICK) {
+        throw new Error('Not enough movies returned from picker');
+      }
+      const schedule = createEmptySchedule();
+      const next = schedule.map((slot, index) => ({
+        ...slot,
+        movie: movies[index] || null,
+      }));
+      if (next.some((slot) => !slot.movie)) {
+        throw new Error('Missing movie data for one or more days');
+      }
+      setPicks(next);
+      setHasUnsavedChanges(true);
+    } catch (err) {
+      setError(err.message || 'Failed to pick movies');
+    } finally {
+      setSpinLoading(false);
+    }
+  }
+
+  async function handleSave() {
+    if (picks.some((pick) => !pick.movie)) {
+      setError('Pick movies for each day before saving.');
+      return;
+    }
+    setSaving(true);
+    setError('');
+    setSuccess('');
+    try {
+      let token;
+      if (user && typeof user.getIdToken === 'function') {
+        try {
+          token = await user.getIdToken();
+        } catch (tokenErr) {
+          console.warn('Failed to fetch auth token', tokenErr);
+        }
+      }
+      const payload = picks.map((pick) => ({ date: pick.date, movie: pick.movie }));
+      const saved = await saveWeeklyPicks(payload, token);
+      if (saved && Array.isArray(saved.picks)) {
+        setPicks(sortAndFormatPicks(saved.picks));
+        setLastSavedDoc(saved);
+      }
+      setHasUnsavedChanges(false);
+      setSuccess('Weekly picks saved to Firestore.');
+    } catch (err) {
+      setError(err.message || 'Failed to save weekly picks');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Layout>
+      <div className="max-w-5xl mx-auto">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
+          <div>
+            <h1 className="text-3xl font-semibold">Weekly Picks</h1>
+            <p className="opacity-80">Plan the next seven days of movie nights.</p>
+          </div>
+          {!hasMovies ? (
+            <button
+              type="button"
+              onClick={handlePickMovies}
+              className={`btn btn-primary ${spinLoading ? 'loading' : ''}`}
+              disabled={spinLoading}
+            >
+              {spinLoading ? 'Picking…' : 'Pick Movies'}
+            </button>
+          ) : (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleSave}
+                className={`btn btn-primary ${saving ? 'loading' : ''}`}
+                disabled={saving || !hasUnsavedChanges}
+              >
+                {saving ? 'Saving…' : hasUnsavedChanges ? 'Save Picks' : 'Saved'}
+              </button>
+              <button
+                type="button"
+                onClick={handlePickMovies}
+                className={`btn btn-secondary ${spinLoading ? 'loading' : ''}`}
+                disabled={spinLoading}
+              >
+                {spinLoading ? 'Spinning…' : 'Spin Again'}
+              </button>
+            </div>
+          )}
+        </div>
+
+        {lastSavedMillis && (
+          <p className="text-sm opacity-70 mb-3">
+            Last saved {savedAtFormatter.format(new Date(lastSavedMillis))}
+            {hasUnsavedChanges ? ' — unsaved changes pending.' : '.'}
+          </p>
+        )}
+        {!lastSavedMillis && hasUnsavedChanges && (
+          <p className="text-sm opacity-70 mb-3">Unsaved picks — don’t forget to save them.</p>
+        )}
+
+        {error && <div className="alert alert-error mb-4">{error}</div>}
+        {success && <div className="alert alert-success mb-4">{success}</div>}
+
+        {initialLoading ? (
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {Array.from({ length: DAYS_TO_PICK }).map((_, index) => (
+              <div key={index} className="skeleton h-40" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {picks.map((pick) => (
+              <WeeklyPickCard key={pick.date} pick={pick} />
+            ))}
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/web/src/ui/Header.jsx
+++ b/web/src/ui/Header.jsx
@@ -2,20 +2,35 @@ import { Link, useLocation } from 'react-router-dom';
 
 export default function Header({ search, onSearchChange }) {
   const { pathname } = useLocation();
+  const showSearch = typeof onSearchChange === 'function';
+  const searchValue = typeof search === 'string' ? search : '';
   return (
     <header className="navbar bg-base-200 sticky top-0 z-10">
       <div className="flex-1">
         <Link to="/" className="btn btn-ghost normal-case text-xl">Movie Catalog</Link>
       </div>
-      <div className="flex-none">
-        <Link to="/ai" className={`btn btn-ghost mr-2 ${pathname === '/ai' ? 'btn-active' : ''}`}>AI</Link>
-        <input
-          type="text"
-          placeholder="Search"
-          className="input input-bordered w-24 md:w-auto"
-          value={search}
-          onChange={(e) => onSearchChange(e.target.value)}
-        />
+      <div className="flex-none flex items-center gap-2">
+        <Link
+          to="/weekly"
+          className={`btn btn-ghost ${pathname === '/weekly' ? 'btn-active' : ''}`}
+        >
+          Weekly Picks
+        </Link>
+        <Link
+          to="/ai"
+          className={`btn btn-ghost ${pathname === '/ai' ? 'btn-active' : ''}`}
+        >
+          AI
+        </Link>
+        {showSearch && (
+          <input
+            type="text"
+            placeholder="Search"
+            className="input input-bordered w-24 md:w-auto"
+            value={searchValue}
+            onChange={(e) => onSearchChange(e.target.value)}
+          />
+        )}
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- extend the randomItems HTTPS function to support custom counts and add endpoints for saving and loading weekly picks in Firestore
- expose weekly pick API helpers to the frontend and add a dedicated Weekly Picks page wired to the Cloud Functions
- update routing and navigation to surface the new planner page for selecting, reviewing, and saving seven daily picks

## Testing
- `npm test`
- `npm run lint` *(fails: existing lint issues in HeroCarousel and MovieDialog)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d762554c8323a2ed384f1763c598