### PR TITLE
Add Firebase login flow with profile page and user menu

### DIFF
--- a/docs/schemas/profile.schema.json
+++ b/docs/schemas/profile.schema.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/schemas/profile.json",
+  "name": "UserProfile",
+  "description": "Schema for a user profile document stored in the Firestore `profiles` collection.",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "id": { "type": "string", "description": "Firestore document ID", "readOnly": true },
+    "uid": { "type": "string", "description": "Firebase Authentication user ID (mirrors the document ID)" },
+    "displayName": { "type": "string", "description": "Preferred name to show in the UI" },
+    "email": { "type": "string", "format": "email", "description": "Primary email address" },
+    "photoURL": { "type": "string", "format": "uri", "description": "Avatar image URL" },
+    "bio": { "type": "string", "description": "Short biography or profile description" },
+    "location": { "type": "string", "description": "Free-form location text" },
+    "website": { "type": "string", "format": "uri", "description": "Personal website or portfolio URL" },
+    "favoriteGenres": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of preferred movie genres"
+    },
+    "favoriteMovies": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "List of all-time favorite movies"
+    },
+    "links": {
+      "type": "object",
+      "description": "Mapping of social handles or related URLs",
+      "additionalProperties": { "type": "string", "format": "uri" }
+    },
+    "createdAt": {
+      "description": "Creation timestamp (milliseconds since epoch, ISO string, or Firestore Timestamp)",
+      "oneOf": [
+        { "type": "integer" },
+        { "type": "string", "format": "date-time" },
+        {
+          "type": "object",
+          "properties": {
+            "seconds": { "type": "integer" },
+            "nanoseconds": { "type": "integer" }
+          },
+          "required": ["seconds"],
+          "additionalProperties": true
+        }
+      ]
+    },
+    "updatedAt": {
+      "description": "Last update timestamp (milliseconds since epoch, ISO string, or Firestore Timestamp)",
+      "oneOf": [
+        { "type": "integer" },
+        { "type": "string", "format": "date-time" },
+        {
+          "type": "object",
+          "properties": {
+            "seconds": { "type": "integer" },
+            "nanoseconds": { "type": "integer" }
+          },
+          "required": ["seconds"],
+          "additionalProperties": true
+        }
+      ]
+    }
+  },
+  "examples": [
+    {
+      "uid": "abc123",
+      "displayName": "Jamie Rivera",
+      "email": "jamie@example.com",
+      "photoURL": "https://example.com/avatars/jamie.png",
+      "bio": "Movie enthusiast and weekend critic.",
+      "location": "Austin, TX",
+      "favoriteGenres": ["Sci-Fi", "Thriller", "Drama"],
+      "favoriteMovies": ["Arrival", "Blade Runner", "Dune"],
+      "links": {
+        "letterboxd": "https://letterboxd.com/jamie",
+        "instagram": "https://instagram.com/jamiewatches"
+      },
+      "createdAt": 1736467200000,
+      "updatedAt": {
+        "seconds": 1737058800,
+        "nanoseconds": 0
+      }
+    }
+  ]
+}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,16 +1,23 @@
 import { Routes, Route } from 'react-router-dom';
 import AuthGate from './auth/AuthGate.jsx';
+import ProtectedRoute from './auth/ProtectedRoute.jsx';
 import MoviesPage from './pages/MoviesPage.jsx';
 import AIFindMovie from './pages/AIFindMovie.jsx';
 import WeeklyPicks from './pages/WeeklyPicks.jsx';
+import LoginPage from './pages/LoginPage.jsx';
+import ProfilePage from './pages/ProfilePage.jsx';
 
 export default function App() {
   return (
     <AuthGate>
       <Routes>
-        <Route path="/" element={<MoviesPage />} />
-        <Route path="/weekly" element={<WeeklyPicks />} />
-        <Route path="/ai" element={<AIFindMovie />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route element={<ProtectedRoute />}>
+          <Route path="/" element={<MoviesPage />} />
+          <Route path="/weekly" element={<WeeklyPicks />} />
+          <Route path="/ai" element={<AIFindMovie />} />
+          <Route path="/profile" element={<ProfilePage />} />
+        </Route>
       </Routes>
     </AuthGate>
   );

--- a/web/src/auth/AuthGate.jsx
+++ b/web/src/auth/AuthGate.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react';
 import { auth, provider } from '../firebase.js';
 import { onAuthStateChanged, signInWithPopup, signOut } from 'firebase/auth';
 
@@ -18,18 +18,18 @@ export default function AuthGate({ children }) {
     return () => unsub();
   }, []);
 
-  const login = () => signInWithPopup(auth, provider);
-  const logout = () => signOut(auth);
+  const login = useCallback(() => signInWithPopup(auth, provider), []);
+  const logout = useCallback(() => signOut(auth), []);
 
-  if (loading) return <p>Loading...</p>;
-  if (!user) return <button onClick={login}>Sign in with Google</button>;
+  const value = useMemo(() => ({ user, login, logout, loading }), [user, login, logout, loading]);
 
-  return (
-    <AuthContext.Provider value={{ user }}>
-      <div>
-        <button onClick={logout}>Sign out</button>
-        {children}
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-base-200 text-base-content">
+        <span className="loading loading-spinner loading-lg" aria-label="Loading" />
       </div>
-    </AuthContext.Provider>
-  );
+    );
+  }
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/web/src/auth/ProtectedRoute.jsx
+++ b/web/src/auth/ProtectedRoute.jsx
@@ -1,0 +1,17 @@
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { useAuth } from './AuthGate.jsx';
+
+export default function ProtectedRoute({ children }) {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  if (children) {
+    return children;
+  }
+
+  return <Outlet />;
+}

--- a/web/src/pages/LoginPage.jsx
+++ b/web/src/pages/LoginPage.jsx
@@ -1,0 +1,56 @@
+import { useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../auth/AuthGate.jsx';
+
+export default function LoginPage() {
+  const { user, login } = useAuth();
+  const location = useLocation();
+  const [error, setError] = useState('');
+  const [signingIn, setSigningIn] = useState(false);
+
+  const fromPath = location.state?.from?.pathname;
+  const redirectTo = fromPath && fromPath !== '/login' ? fromPath : '/';
+
+  if (user) {
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  async function handleLogin() {
+    setError('');
+    setSigningIn(true);
+    try {
+      await login();
+    } catch (err) {
+      setError(err.message || 'Failed to sign in. Please try again.');
+      setSigningIn(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-base-200 text-base-content p-4">
+      <div className="w-full max-w-md bg-base-100 shadow-xl rounded-box p-8 space-y-6">
+        <div className="space-y-2 text-center">
+          <h1 className="text-3xl font-semibold">Welcome back</h1>
+          <p className="opacity-80">Sign in to continue to the movie catalog.</p>
+        </div>
+        {fromPath && (
+          <div className="alert alert-info text-sm">
+            Sign in to view <span className="font-semibold">{fromPath}</span>.
+          </div>
+        )}
+        {error && <div className="alert alert-error text-sm">{error}</div>}
+        <button
+          type="button"
+          onClick={handleLogin}
+          className={`btn btn-primary w-full ${signingIn ? 'loading' : ''}`}
+          disabled={signingIn}
+        >
+          {signingIn ? 'Signing in…' : 'Sign in with Google'}
+        </button>
+        <p className="text-xs text-center opacity-70">
+          We use Firebase Authentication to keep your account secure.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/ProfilePage.jsx
+++ b/web/src/pages/ProfilePage.jsx
@@ -1,0 +1,191 @@
+import { useEffect, useMemo, useState } from 'react';
+import { doc, onSnapshot } from 'firebase/firestore';
+import { UserCircleIcon } from '@heroicons/react/24/solid';
+import Layout from '../ui/Layout.jsx';
+import { useAuth } from '../auth/AuthGate.jsx';
+import { db } from '../firebase.js';
+
+function formatKey(key) {
+  if (typeof key !== 'string') return 'Field';
+  return key
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/^\w/, (char) => char.toUpperCase());
+}
+
+function formatValue(value) {
+  if (value === null || value === undefined) {
+    return <span className="opacity-60">—</span>;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim() ? value : <span className="opacity-60">—</span>;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  if (value instanceof Date) {
+    return value.toLocaleString();
+  }
+
+  if (value && typeof value.toDate === 'function') {
+    const asDate = value.toDate();
+    if (asDate instanceof Date && !Number.isNaN(asDate.getTime())) {
+      return asDate.toLocaleString();
+    }
+  }
+
+  if (value && typeof value.seconds === 'number') {
+    const asDate = new Date(value.seconds * 1000);
+    if (!Number.isNaN(asDate.getTime())) {
+      return asDate.toLocaleString();
+    }
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return <span className="opacity-60">—</span>;
+    }
+    return value
+      .map((item) => {
+        if (item === null || item === undefined) return '—';
+        if (typeof item === 'string' || typeof item === 'number' || typeof item === 'boolean') {
+          return String(item);
+        }
+        if (item && typeof item.toDate === 'function') {
+          const asDate = item.toDate();
+          if (asDate instanceof Date && !Number.isNaN(asDate.getTime())) {
+            return asDate.toLocaleString();
+          }
+        }
+        return JSON.stringify(item);
+      })
+      .join(', ');
+  }
+
+  if (typeof value === 'object') {
+    return (
+      <pre className="whitespace-pre-wrap break-words text-xs bg-base-300/60 rounded-box p-3">
+        {JSON.stringify(value, null, 2)}
+      </pre>
+    );
+  }
+
+  return String(value);
+}
+
+export default function ProfilePage() {
+  const { user } = useAuth();
+  const [profile, setProfile] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setProfile(null);
+      setLoading(false);
+      return undefined;
+    }
+
+    setLoading(true);
+    setError('');
+    const ref = doc(db, import.meta.env.VITE_PROFILE_COLLECTION || 'profiles', user.uid);
+    const unsubscribe = onSnapshot(
+      ref,
+      (snapshot) => {
+        if (snapshot.exists()) {
+          setProfile(snapshot.data());
+        } else {
+          setProfile(null);
+        }
+        setLoading(false);
+      },
+      (err) => {
+        console.error('Failed to read profile', err);
+        setError(err.message || 'Failed to load profile data.');
+        setLoading(false);
+      },
+    );
+
+    return () => unsubscribe();
+  }, [user?.uid]);
+
+  const docData = useMemo(() => profile || {}, [profile]);
+  const avatarUrl = docData.photoURL || user?.photoURL || '';
+  const displayName = docData.displayName || user?.displayName || 'Movie fan';
+  const email = docData.email || user?.email || '';
+
+  const detailEntries = useMemo(() => {
+    const entries = Object.entries(docData).filter(
+      ([key]) => !['displayName', 'email', 'photoURL'].includes(key),
+    );
+    entries.sort(([a], [b]) => a.localeCompare(b));
+    return entries;
+  }, [docData]);
+
+  const creationDate = user?.metadata?.creationTime ? new Date(user.metadata.creationTime) : null;
+  const lastSignInDate = user?.metadata?.lastSignInTime ? new Date(user.metadata.lastSignInTime) : null;
+
+  return (
+    <Layout>
+      <div className="max-w-3xl mx-auto">
+        <div className="card bg-base-200 shadow-lg">
+          <div className="card-body gap-6">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-6">
+              <div className="avatar">
+                <div className="w-24 h-24 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2 bg-base-300 overflow-hidden flex items-center justify-center">
+                  {avatarUrl ? (
+                    <img src={avatarUrl} alt={displayName} className="w-full h-full object-cover" />
+                  ) : (
+                    <UserCircleIcon className="w-16 h-16 text-base-content/60" />
+                  )}
+                </div>
+              </div>
+              <div className="space-y-1">
+                <h1 className="text-3xl font-semibold">{displayName}</h1>
+                {email && <p className="text-sm opacity-80">{email}</p>}
+                <p className="text-xs opacity-70">UID: {user?.uid}</p>
+                <div className="text-xs opacity-70 space-y-1">
+                  {creationDate && !Number.isNaN(creationDate.getTime()) && (
+                    <p>Account created: {creationDate.toLocaleString()}</p>
+                  )}
+                  {lastSignInDate && !Number.isNaN(lastSignInDate.getTime()) && (
+                    <p>Last sign-in: {lastSignInDate.toLocaleString()}</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            {error && <div className="alert alert-error text-sm">{error}</div>}
+
+            {loading ? (
+              <div className="space-y-3">
+                <div className="skeleton h-4 w-1/2" />
+                <div className="skeleton h-4 w-2/3" />
+                <div className="skeleton h-4 w-1/3" />
+              </div>
+            ) : detailEntries.length > 0 ? (
+              <div className="space-y-4">
+                <h2 className="text-lg font-semibold">Profile details</h2>
+                <dl className="rounded-box border border-base-300 divide-y divide-base-300">
+                  {detailEntries.map(([key, value]) => (
+                    <div key={key} className="grid grid-cols-1 sm:grid-cols-3 gap-2 px-4 py-3">
+                      <dt className="text-sm font-medium uppercase tracking-wide text-base-content/70">
+                        {formatKey(key)}
+                      </dt>
+                      <dd className="text-sm sm:col-span-2 break-words">{formatValue(value)}</dd>
+                    </div>
+                  ))}
+                </dl>
+              </div>
+            ) : (
+              <p className="opacity-70">No additional profile details stored in Firestore yet.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/web/src/ui/Header.jsx
+++ b/web/src/ui/Header.jsx
@@ -1,4 +1,59 @@
 import { Link, useLocation } from 'react-router-dom';
+import { UserCircleIcon } from '@heroicons/react/24/solid';
+import { useAuth } from '../auth/AuthGate.jsx';
+
+function UserMenu() {
+  const { user, logout } = useAuth();
+
+  if (!user) return null;
+
+  const avatar = user.photoURL;
+  const name = user.displayName || user.email || 'Signed in user';
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } catch (err) {
+      console.error('Failed to sign out', err);
+    }
+  }
+
+  return (
+    <div className="dropdown dropdown-end">
+      <button
+        type="button"
+        className="btn btn-ghost btn-circle avatar"
+        tabIndex={0}
+        aria-label="User menu"
+      >
+        <div className="w-10 rounded-full overflow-hidden bg-base-300 flex items-center justify-center">
+          {avatar ? (
+            <img src={avatar} alt={name} className="w-full h-full object-cover" />
+          ) : (
+            <UserCircleIcon className="w-7 h-7 text-base-content/70" />
+          )}
+        </div>
+      </button>
+      <ul
+        tabIndex={0}
+        className="menu menu-sm dropdown-content mt-3 w-56 rounded-box bg-base-200 p-2 shadow"
+      >
+        <li className="mb-2 px-2 py-2 text-sm">
+          <p className="font-semibold leading-tight">{name}</p>
+          {user.email && <p className="text-xs opacity-70">{user.email}</p>}
+        </li>
+        <li>
+          <Link to="/profile">View profile</Link>
+        </li>
+        <li>
+          <button type="button" onClick={handleLogout}>
+            Log out
+          </button>
+        </li>
+      </ul>
+    </div>
+  );
+}
 
 export default function Header({ search, onSearchChange }) {
   const { pathname } = useLocation();
@@ -31,6 +86,7 @@ export default function Header({ search, onSearchChange }) {
             onChange={(e) => onSearchChange(e.target.value)}
           />
         )}
+        <UserMenu />
       </div>
     </header>
   );

--- a/web/src/ui/movies/MovieDialog.jsx
+++ b/web/src/ui/movies/MovieDialog.jsx
@@ -1,28 +1,27 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { deleteItem, updateItem } from '../../api/functions.js';
 
 export default function MovieDialog({ movie, open, onClose, onDeleted }) {
-
-
-
-  if (!movie) return null;
-  const title = movie.title || movie.name || '(untitled)';
-  const year = movie.year ? `(${movie.year})` : '';
-  const genres = Array.isArray(movie.genre) ? movie.genre : [];
-  const actors = Array.isArray(movie.actors) ? movie.actors : [];
+  const hasMovie = Boolean(movie);
+  const title = movie?.title || movie?.name || '(untitled)';
+  const year = movie?.year ? `(${movie.year})` : '';
+  const genres = Array.isArray(movie?.genre) ? movie.genre : [];
+  const actors = Array.isArray(movie?.actors) ? movie.actors : [];
   const [deleting, setDeleting] = useState(false);
   const [markingWatched, setMarkingWatched] = useState(false);
-  const [lastWatched, setLastWatched] = useState(movie.lastWatched);
+  const [lastWatched, setLastWatched] = useState(movie?.lastWatched);
 
   useEffect(() => {
-    if (!movie) setDeleting(false);
-  }, [movie]);
-
-  useEffect(() => {
+    if (!hasMovie) {
+      setDeleting(false);
+      setMarkingWatched(false);
+      setLastWatched(undefined);
+      return;
+    }
     setLastWatched(movie.lastWatched);
     setMarkingWatched(false);
     setDeleting(false);
-  }, [movie]);
+  }, [hasMovie, movie?.id, movie?.lastWatched]);
 
   let lastWatchedInfo = null;
   if (lastWatched !== undefined && lastWatched !== null) {
@@ -74,6 +73,9 @@ export default function MovieDialog({ movie, open, onClose, onDeleted }) {
       setDeleting(false);
     }
   }
+
+  if (!hasMovie) return null;
+
   return (
     <dialog open={open} className={`modal ${open ? 'modal-open' : ''}`} onClose={onClose}>
       {/* Constrain dialog to viewport and use a portrait layout */}
@@ -121,8 +123,7 @@ export default function MovieDialog({ movie, open, onClose, onDeleted }) {
           <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             {lastWatchedInfo && (
               <p className="text-sm text-base-content/70">
-                Last watched:{' '}
-                <time dateTime={lastWatchedInfo.iso}>{lastWatchedInfo.label}</time>
+                Last watched: <time dateTime={lastWatchedInfo.iso}>{lastWatchedInfo.label}</time>
               </p>
             )}
             <div className="flex justify-end gap-2">


### PR DESCRIPTION
## Summary
- add a dedicated login route with a protected routing layer and updated AuthGate context
- surface the signed-in user in the header with a profile/logout dropdown and create a Firestore-backed profile page
- document the Firestore user profile model in docs/schemas/profile.schema.json

## Testing
- npm run lint
- npm run test *(fails: Firebase auth invalid-api-key because test env lacks Firebase credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e80654d4832391d0247d262d7742