### PR TITLE
Stub auth context to unblock MoviesPage test

### DIFF
--- a/web/src/auth/AuthGate.jsx
+++ b/web/src/auth/AuthGate.jsx
@@ -26,7 +26,7 @@ export default function AuthGate({ children }) {
     (async () => {
       try {
         await setPersistence(auth, browserLocalPersistence);
-      } catch (_) {
+      } catch {
         // ignore, defaults will apply
       }
 
@@ -66,7 +66,7 @@ export default function AuthGate({ children }) {
     try {
       // Use popup first per request
       return await signInWithPopup(auth, provider);
-    } catch (err) {
+    } catch {
       // Optional fallback to redirect if popup is blocked
       try {
         return await signInWithRedirect(auth, provider);

--- a/web/src/firebase.js
+++ b/web/src/firebase.js
@@ -23,7 +23,7 @@ if (import.meta.env.DEV && import.meta.env.VITE_FIRESTORE_EMULATOR_HOST) {
   if (host && port) {
     try {
       connectFirestoreEmulator(db, host, Number(port));
-    } catch (e) {
+    } catch {
       // no-op if already connected
     }
   }

--- a/web/src/pages/LoginPage.jsx
+++ b/web/src/pages/LoginPage.jsx
@@ -13,6 +13,12 @@ export default function LoginPage() {
   const fromPath = location.state?.from?.pathname;
   const redirectTo = '/';
 
+  useEffect(() => {
+    if (authError && signingIn) {
+      setSigningIn(false);
+    }
+  }, [authError, signingIn]);
+
   if (user) {
     return <Navigate to={redirectTo} replace />;
   }
@@ -30,12 +36,6 @@ export default function LoginPage() {
       setSigningIn(false);
     }
   }
-
-  useEffect(() => {
-    if (authError && signingIn) {
-      setSigningIn(false);
-    }
-  }, [authError, signingIn]);
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-base-200 text-base-content p-4">

--- a/web/src/pages/MoviesPage.test.jsx
+++ b/web/src/pages/MoviesPage.test.jsx
@@ -1,8 +1,22 @@
-import { render, screen } from '@testing-library/react';
-import MoviesPage from './MoviesPage.jsx';
 import { vi, test, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../auth/AuthGate.jsx', () => {
+  const mockAuth = {
+    user: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    loading: false,
+    authError: null,
+    clearAuthError: vi.fn(),
+  };
+  return {
+    useAuth: () => mockAuth,
+    default: ({ children }) => children,
+  };
+});
 
 vi.mock('../hooks/useMoviesQuery.js', () => ({
   default: () => ({
@@ -13,6 +27,8 @@ vi.mock('../hooks/useMoviesQuery.js', () => ({
     query: { q: '', genre: '', sort: 'title', dir: 'asc', page: 0 },
   }),
 }));
+
+import MoviesPage from './MoviesPage.jsx';
 
 test('renders movie grid and search', () => {
   render(

--- a/web/src/ui/Header.jsx
+++ b/web/src/ui/Header.jsx
@@ -5,17 +5,16 @@ import { useEffect, useState } from 'react';
 
 function UserMenu() {
   const { user, logout } = useAuth();
-
-  if (!user) return null;
-
   const [avatarError, setAvatarError] = useState(false);
-  const avatar = user.photoURL;
-  const name = user.displayName || user.email || 'Signed in user';
+  const avatar = user?.photoURL;
+  const name = user?.displayName || user?.email || 'Signed in user';
 
   useEffect(() => {
     // Reset error state when avatar URL changes
     setAvatarError(false);
   }, [avatar]);
+
+  if (!user) return null;
 
   async function handleLogout() {
     try {
@@ -56,7 +55,7 @@ function UserMenu() {
       >
         <li className="mb-2 px-2 py-2 text-sm">
           <p className="font-semibold leading-tight">{name}</p>
-          {user.email && <p className="text-xs opacity-70">{user.email}</p>}
+          {user?.email && <p className="text-xs opacity-70">{user.email}</p>}
         </li>
         <li>
           <Link to="/profile">View profile</Link>


### PR DESCRIPTION
## Summary
- mock the auth gate module in the MoviesPage test so Firebase isn't initialized during unit runs
- keep the movies query stub to assert the grid and search render as expected

## Testing
- npm --prefix web run lint
- npm --prefix web run test

------
https://chatgpt.com/codex/tasks/task_e_68ca09c00a408323be3d9cebed106bdd