### PR TITLE
Adjust hero carousel to 16x9 ratio

### DIFF
--- a/web/src/ui/movies/HeroCarousel.jsx
+++ b/web/src/ui/movies/HeroCarousel.jsx
@@ -65,7 +65,10 @@ export default function HeroCarousel({ items = [], onSelect }) {
   if (length === 0) return null;
 
   return (
-    <div ref={containerRef} className="carousel w-full mb-6 h-64 md:h-80 lg:h-96 rounded-box overflow-hidden">
+    <div
+      ref={containerRef}
+      className="carousel w-full mb-6 aspect-[16/9] xl:aspect-[160/81] rounded-box overflow-hidden"
+    >
       {items.map((m, idx) => {
         const bg = bgFor(m);
         const title = m.title || m.name || '(untitled)';
@@ -74,7 +77,7 @@ export default function HeroCarousel({ items = [], onSelect }) {
         return (
           <div
             id={`hero-slide-${idx}`}
-            className="carousel-item relative w-full"
+            className="carousel-item relative w-full h-full"
             key={m.id || idx}
             aria-hidden={!isActive}
             data-active={isActive ? 'true' : undefined}

--- a/web/src/ui/movies/HeroCarousel.test.jsx
+++ b/web/src/ui/movies/HeroCarousel.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { beforeAll, afterEach, describe, expect, test, vi } from 'vitest';
+import '@testing-library/jest-dom';
+
+import HeroCarousel from './HeroCarousel.jsx';
+
+const heroItems = [
+  {
+    id: 'hero-1',
+    title: 'First Feature',
+    year: 2021,
+    landscape_poster_link: 'https://example.com/poster-1.jpg',
+  },
+  {
+    id: 'hero-2',
+    title: 'Second Story',
+    year: 2019,
+    poster_link: 'https://example.com/poster-2.jpg',
+  },
+];
+
+beforeAll(() => {
+  Element.prototype.scrollTo = vi.fn();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('HeroCarousel', () => {
+  test('renders slides and calls onSelect when hero title is clicked', () => {
+    const handleSelect = vi.fn();
+    render(<HeroCarousel items={heroItems} onSelect={handleSelect} />);
+
+    const heroButton = screen.getByRole('button', {
+      name: /view details for first feature/i,
+    });
+    fireEvent.click(heroButton);
+
+    expect(handleSelect).toHaveBeenCalledTimes(1);
+    expect(handleSelect).toHaveBeenCalledWith(heroItems[0]);
+  });
+
+  test('advances to the next slide when the next button is pressed', async () => {
+    render(<HeroCarousel items={heroItems} onSelect={() => {}} />);
+
+    const nextButton = screen.getByRole('button', { name: /next/i });
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      const secondSlide = document.getElementById('hero-slide-1');
+      expect(secondSlide).toHaveAttribute('data-active', 'true');
+    });
+
+    const firstSlide = document.getElementById('hero-slide-0');
+    expect(firstSlide).not.toHaveAttribute('data-active');
+  });
+});


### PR DESCRIPTION
## Summary
- replace the fixed height hero carousel sizing with an aspect ratio driven layout
- keep a standard 16:9 frame while allowing a slightly shorter 160:81 ratio on very wide screens
- ensure each carousel item fills the computed height so backgrounds remain full bleed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc9397f0808323906187413c914449